### PR TITLE
Use include instead of match

### DIFF
--- a/WebpackGrabber.user.js
+++ b/WebpackGrabber.user.js
@@ -5,7 +5,7 @@
 // @author          Vendicated (https://github.com/Vendicated)
 // @namespace       https://github.com/Vendicated/WebpackGrabber
 // @license         GPL-3.0
-// @match           *://*/*
+// @include *
 // @grant           none
 // @run-at          document-start
 // ==/UserScript==


### PR DESCRIPTION
`match` seems to not be working on Violentmonkey, havent tested with other userscript loaders. Switched to use `include` instead of `match` as it seems to work.